### PR TITLE
Update search function to use Redmine API directly

### DIFF
--- a/src/lib/redmine.ts
+++ b/src/lib/redmine.ts
@@ -305,13 +305,16 @@ async function trackTimeInRedmine(
   }
 }
 
+// Function to search issues using the standard Redmine API
 async function searchIssues(
   searchQuery: string,
   redmineAuth: RedmineAuth
 ): Promise<any[]> {
   const encodedQuery = encodeURIComponent(searchQuery);
   const url =
-    `${"https://redmine-lite.netlify.app/api"}/issues.json?` +
+    `${validateAndAdjustRedmineUrl(
+      process.env.REDMINE_API_URL!
+    )}issues.json?` +
     `offset=0&limit=20&` +
     `f[]=subject&op[subject]=~&v[subject][]=${encodedQuery}` +
     `&sort=updated_on:desc`;


### PR DESCRIPTION
Update the `searchIssues` function to use the `REDMINE_API_URL` from the `.env` file.

* Construct the search URL using the `REDMINE_API_URL` variable.
* Add a comment to indicate that the standard Redmine API is being used.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/penkobor/redmine-toggle-tracker/pull/7?shareId=5f3ec35c-7983-42f8-90ef-0e797d0b1ddf).