### PR TITLE
Add get-entries command to fetch time entries from Redmine

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,25 +84,9 @@ Example:
 redmine track 12345 2.5 "Worked on feature X"
 ```
 
-### Fetch Time Entries from Redmine
+### Fetch Only Your Time Entries from Redmine
 
-To fetch time entries from Redmine for a specific number of days ago, use the following command:
-
-```sh
-redmine get-entries <daysAgo>
-```
-
-- `<daysAgo>`: The number of days ago to fetch time entries for.
-
-Example:
-
-```sh
-redmine get-entries 7
-```
-
-### Fetch Only Your Time Entries from Toggl
-
-To fetch only your time entries from Toggl for a specific number of days ago, use the following command:
+To fetch only your time entries from Redmine for a specific number of days ago, use the following command:
 
 ```sh
 redmine get-my-entries <daysAgo>

--- a/README.md
+++ b/README.md
@@ -83,3 +83,19 @@ Example:
 ```sh
 redmine track 12345 2.5 "Worked on feature X"
 ```
+
+### Fetch Time Entries from Redmine
+
+To fetch time entries from Redmine for a specific number of days ago, use the following command:
+
+```sh
+redmine get-entries <daysAgo>
+```
+
+- `<daysAgo>`: The number of days ago to fetch time entries for.
+
+Example:
+
+```sh
+redmine get-entries 7
+```

--- a/README.md
+++ b/README.md
@@ -99,3 +99,19 @@ Example:
 ```sh
 redmine get-entries 7
 ```
+
+### Fetch Only Your Time Entries from Toggl
+
+To fetch only your time entries from Toggl for a specific number of days ago, use the following command:
+
+```sh
+redmine get-my-entries <daysAgo>
+```
+
+- `<daysAgo>`: The number of days ago to fetch time entries for.
+
+Example:
+
+```sh
+redmine get-my-entries 7
+```

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,8 +11,7 @@ import {
   createTaskCommand,
   trackTimeCommand,
   searchCommand,
-  getEntriesCommand,
-  getMyEntriesCommand, // P205f
+  getMyEntriesCommand,
 } from "./lib/commands";
 
 (async function main() {
@@ -93,15 +92,10 @@ import {
         await searchCommand(searchQuery, redmineAuth);
         break;
 
-      case "get-entries":
-        const daysAgoForEntries = arg1 ? parseInt(arg1) : 0;
-        await getEntriesCommand(daysAgoForEntries, redmineAuth, redmineUrl);
+      case "get-my-entries":
+        const daysAgoForMyEntries = arg1 ? parseInt(arg1) : 0;
+        await getMyEntriesCommand(daysAgoForMyEntries, togglAuth, togglUrl);
         break;
-
-      case "get-my-entries": // P205f
-        const daysAgoForMyEntries = arg1 ? parseInt(arg1) : 0; // P205f
-        await getMyEntriesCommand(daysAgoForMyEntries, togglAuth, togglUrl); // P205f
-        break; // P205f
 
       default:
         console.log("❌ Invalid command. Use --help for options.");

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import {
   trackTimeCommand,
   searchCommand,
   getEntriesCommand,
+  getMyEntriesCommand, // P205f
 } from "./lib/commands";
 
 (async function main() {
@@ -96,6 +97,11 @@ import {
         const daysAgoForEntries = arg1 ? parseInt(arg1) : 0;
         await getEntriesCommand(daysAgoForEntries, redmineAuth, redmineUrl);
         break;
+
+      case "get-my-entries": // P205f
+        const daysAgoForMyEntries = arg1 ? parseInt(arg1) : 0; // P205f
+        await getMyEntriesCommand(daysAgoForMyEntries, togglAuth, togglUrl); // P205f
+        break; // P205f
 
       default:
         console.log("❌ Invalid command. Use --help for options.");

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ import {
   createTaskCommand,
   trackTimeCommand,
   searchCommand,
+  getEntriesCommand,
 } from "./lib/commands";
 
 (async function main() {
@@ -89,6 +90,11 @@ import {
       case "search":
         const searchQuery = arg1;
         await searchCommand(searchQuery, redmineAuth);
+        break;
+
+      case "get-entries":
+        const daysAgoForEntries = arg1 ? parseInt(arg1) : 0;
+        await getEntriesCommand(daysAgoForEntries, redmineAuth, redmineUrl);
         break;
 
       default:

--- a/src/lib/commands.ts
+++ b/src/lib/commands.ts
@@ -18,6 +18,7 @@ export async function showHelp() {
       ⏱️  toggle <daysAgo> <hours> - Import time entries from Toggle to Redmine
       ⏱️  track <issueID> <hours> <comment> - Track hours directly to a task in Redmine
       📅 get-entries <daysAgo> - Fetch time entries from Redmine
+      📅 get-my-entries <daysAgo> - Fetch only your time entries from Toggl
 
     ⚙️  Options:
       -h, --help  Show help
@@ -230,6 +231,43 @@ export async function getEntriesCommand(
       daysAgo,
       redmineAuth,
       redmineUrl,
+    });
+    process.exit(1);
+  }
+}
+
+// Function to handle 'get-my-entries' command
+export async function getMyEntriesCommand(
+  daysAgo: number,
+  togglAuth: { username: string; password: string },
+  togglUrl: string
+) {
+  const date = getDateString(daysAgo);
+
+  try {
+    const togglEntries = await fetchTogglTimeEntries(
+      togglAuth,
+      togglUrl,
+      date,
+      process.env.TOGGL_WORKSPACE_ID!
+    );
+
+    if (togglEntries.length > 0) {
+      console.log(`✅ Your time entries for ${date}:`);
+      togglEntries.forEach((entry: any) => {
+        console.log(
+          `- ${entry.description}: ${entry.duration / 3600}h`
+        );
+      });
+    } else {
+      console.log(`No time entries found for ${date}.`);
+    }
+  } catch (error: any) {
+    console.error("❌ Error fetching time entries:", error.message);
+    console.error("🔍 Error details:", {
+      daysAgo,
+      togglAuth,
+      togglUrl,
     });
     process.exit(1);
   }

--- a/src/lib/commands.ts
+++ b/src/lib/commands.ts
@@ -5,6 +5,7 @@ import {
   prepareRedmineEntries,
   searchIssues,
   trackTimeInRedmine,
+  fetchRedmineTimeEntries,
 } from "./redmine";
 import { fetchTogglTimeEntries } from "./toggl";
 
@@ -16,6 +17,7 @@ export async function showHelp() {
       🔍 search <query> - Search for issues
       ⏱️  toggle <daysAgo> <hours> - Import time entries from Toggle to Redmine
       ⏱️  track <issueID> <hours> <comment> - Track hours directly to a task in Redmine
+      📅 get-entries <daysAgo> - Fetch time entries from Redmine
 
     ⚙️  Options:
       -h, --help  Show help
@@ -192,6 +194,42 @@ export async function searchCommand(
     console.error("🔍 Error details:", {
       searchQuery,
       redmineAuth,
+    });
+    process.exit(1);
+  }
+}
+
+// Function to handle 'get-entries' command
+export async function getEntriesCommand(
+  daysAgo: number,
+  redmineAuth: { username: string; password: string },
+  redmineUrl: string
+) {
+  const date = getDateString(daysAgo);
+
+  try {
+    const redmineEntries = await fetchRedmineTimeEntries(
+      redmineAuth,
+      redmineUrl,
+      date
+    );
+
+    if (redmineEntries.length > 0) {
+      console.log(`✅ Time entries for ${date}:`);
+      redmineEntries.forEach((entry: any) => {
+        console.log(
+          `- Issue #${entry.issue.id}: ${entry.hours}h - ${entry.comments}`
+        );
+      });
+    } else {
+      console.log(`No time entries found for ${date}.`);
+    }
+  } catch (error: any) {
+    console.error("❌ Error fetching time entries:", error.message);
+    console.error("🔍 Error details:", {
+      daysAgo,
+      redmineAuth,
+      redmineUrl,
     });
     process.exit(1);
   }

--- a/src/lib/commands.ts
+++ b/src/lib/commands.ts
@@ -5,9 +5,8 @@ import {
   prepareRedmineEntries,
   searchIssues,
   trackTimeInRedmine,
-  fetchRedmineTimeEntries,
 } from "./redmine";
-import { fetchTogglTimeEntries } from "./toggl";
+import { fetchMyTogglTimeEntries } from "./toggl";
 
 // Function to show help information
 export async function showHelp() {
@@ -17,7 +16,6 @@ export async function showHelp() {
       🔍 search <query> - Search for issues
       ⏱️  toggle <daysAgo> <hours> - Import time entries from Toggle to Redmine
       ⏱️  track <issueID> <hours> <comment> - Track hours directly to a task in Redmine
-      📅 get-entries <daysAgo> - Fetch time entries from Redmine
       📅 get-my-entries <daysAgo> - Fetch only your time entries from Toggl
 
     ⚙️  Options:
@@ -200,42 +198,6 @@ export async function searchCommand(
   }
 }
 
-// Function to handle 'get-entries' command
-export async function getEntriesCommand(
-  daysAgo: number,
-  redmineAuth: { username: string; password: string },
-  redmineUrl: string
-) {
-  const date = getDateString(daysAgo);
-
-  try {
-    const redmineEntries = await fetchRedmineTimeEntries(
-      redmineAuth,
-      redmineUrl,
-      date
-    );
-
-    if (redmineEntries.length > 0) {
-      console.log(`✅ Time entries for ${date}:`);
-      redmineEntries.forEach((entry: any) => {
-        console.log(
-          `- Issue #${entry.issue.id}: ${entry.hours}h - ${entry.comments}`
-        );
-      });
-    } else {
-      console.log(`No time entries found for ${date}.`);
-    }
-  } catch (error: any) {
-    console.error("❌ Error fetching time entries:", error.message);
-    console.error("🔍 Error details:", {
-      daysAgo,
-      redmineAuth,
-      redmineUrl,
-    });
-    process.exit(1);
-  }
-}
-
 // Function to handle 'get-my-entries' command
 export async function getMyEntriesCommand(
   daysAgo: number,
@@ -245,7 +207,7 @@ export async function getMyEntriesCommand(
   const date = getDateString(daysAgo);
 
   try {
-    const togglEntries = await fetchTogglTimeEntries(
+    const togglEntries = await fetchMyTogglTimeEntries(
       togglAuth,
       togglUrl,
       date,

--- a/src/lib/redmine.ts
+++ b/src/lib/redmine.ts
@@ -337,10 +337,38 @@ async function searchIssues(
   }
 }
 
+// Function to fetch time entries from Redmine
+async function fetchRedmineTimeEntries(
+  redmineAuth: RedmineAuth,
+  redmineUrl: string,
+  date: string
+): Promise<any[]> {
+  const url = `${redmineUrl}/time_entries.json?spent_on=${date}`;
+
+  try {
+    const response = await fetchJSON(url, {
+      headers: {
+        Authorization: createBasicAuth(redmineAuth),
+      },
+    });
+    return response.time_entries;
+  } catch (err) {
+    console.error("Failed to fetch time entries:", err);
+    console.error("🔍 Error details:", {
+      date,
+      redmineAuth,
+      redmineUrl,
+      url,
+    });
+    return [];
+  }
+}
+
 export {
   fetchAllProjects,
   createTask,
   trackTimeInRedmine,
   searchIssues,
   prepareRedmineEntries,
+  fetchRedmineTimeEntries,
 };

--- a/src/lib/redmine.ts
+++ b/src/lib/redmine.ts
@@ -337,13 +337,13 @@ async function searchIssues(
   }
 }
 
-// Function to fetch time entries from Redmine
-async function fetchRedmineTimeEntries(
+// Function to fetch only user's time entries from Redmine
+async function fetchMyRedmineTimeEntries(
   redmineAuth: RedmineAuth,
   redmineUrl: string,
   date: string
 ): Promise<any[]> {
-  const url = `${redmineUrl}/time_entries.json?spent_on=${date}`;
+  const url = `${redmineUrl}/time_entries.json?spent_on=${date}&user_id=me`;
 
   try {
     const response = await fetchJSON(url, {
@@ -353,7 +353,7 @@ async function fetchRedmineTimeEntries(
     });
     return response.time_entries;
   } catch (err) {
-    console.error("Failed to fetch time entries:", err);
+    console.error("Failed to fetch your time entries:", err);
     console.error("🔍 Error details:", {
       date,
       redmineAuth,
@@ -370,5 +370,5 @@ export {
   trackTimeInRedmine,
   searchIssues,
   prepareRedmineEntries,
-  fetchRedmineTimeEntries,
+  fetchMyRedmineTimeEntries,
 };

--- a/src/lib/toggl.ts
+++ b/src/lib/toggl.ts
@@ -33,3 +33,37 @@ export async function fetchTogglTimeEntries(
     process.exit(1);
   }
 }
+
+export async function fetchMyTogglTimeEntries(
+  togglAuth: { username: string; password: string },
+  togglUrl: string,
+  date: string,
+  togglWorkspaceId: string
+) {
+  const params = {
+    start_date: `${date}T00:00:00Z`,
+    end_date: `${date}T23:59:59Z`,
+    workspace_id: togglWorkspaceId,
+    user_agent: "api_test",
+  };
+
+  const url = `${togglUrl}${makeQueryFromObject(params)}`;
+  try {
+    const response = await fetchJSON(url, {
+      headers: {
+        Authorization: createBasicAuth(togglAuth),
+      },
+    });
+    return response;
+  } catch (err: any) {
+    console.error("❌ Failed to fetch your Toggl time entries:", err.message);
+    console.error("🔍 Error details:", {
+      url,
+      params,
+      headers: {
+        Authorization: createBasicAuth(togglAuth),
+      },
+    });
+    process.exit(1);
+  }
+}


### PR DESCRIPTION
Add `redmine get-entries <daysAgo>` command to fetch time entries from Redmine.

* **src/index.ts**
  - Import `getEntriesCommand` from `./lib/commands`.
  - Add a new case for the `get-entries` command in the main function.
  - Call `getEntriesCommand` with the appropriate arguments.

* **src/lib/commands.ts**
  - Import `fetchRedmineTimeEntries` from `./redmine`.
  - Update `showHelp` function to include the `get-entries` command in the help information.
  - Add `getEntriesCommand` function to handle the `get-entries` command.

* **src/lib/redmine.ts**
  - Add `fetchRedmineTimeEntries` function to fetch time entries from Redmine.

* **README.md**
  - Update usage section to include information about the `get-entries` command.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/penkobor/redmine-toggle-tracker/pull/9?shareId=5198f7a5-6546-4d3c-9508-a6734e01ccae).