### PR TITLE
Add get-entries command to fetch and print user's tracked time entries in Redmine

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,3 +83,19 @@ Example:
 ```sh
 redmine track 12345 2.5 "Worked on feature X"
 ```
+
+### Fetch and Print Your Tracked Time Entries
+
+To fetch and print your tracked time entries in Redmine, use the following command:
+
+```sh
+redmine get-entries <daysAgo>
+```
+
+- `<daysAgo>`: The number of days ago to fetch the entries for (default is 0).
+
+Example:
+
+```sh
+redmine get-entries 0
+```

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ import {
   createTaskCommand,
   trackTimeCommand,
   searchCommand,
+  getEntriesCommand,
 } from "./lib/commands";
 
 (async function main() {
@@ -89,6 +90,11 @@ import {
       case "search":
         const searchQuery = arg1;
         await searchCommand(searchQuery, redmineAuth);
+        break;
+
+      case "get-entries":
+        const daysAgoEntries = arg1 ? parseInt(arg1) : 0;
+        await getEntriesCommand(daysAgoEntries, redmineAuth);
         break;
 
       default:

--- a/src/lib/commands.ts
+++ b/src/lib/commands.ts
@@ -5,6 +5,7 @@ import {
   prepareRedmineEntries,
   searchIssues,
   trackTimeInRedmine,
+  fetchUserTimeEntries,
 } from "./redmine";
 import { fetchTogglTimeEntries } from "./toggl";
 
@@ -16,6 +17,7 @@ export async function showHelp() {
       🔍 search <query> - Search for issues
       ⏱️  toggle <daysAgo> <hours> - Import time entries from Toggle to Redmine
       ⏱️  track <issueID> <hours> <comment> - Track hours directly to a task in Redmine
+      📅 get-entries <daysAgo> - Fetch and print your tracked time entries in Redmine
 
     ⚙️  Options:
       -h, --help  Show help
@@ -191,6 +193,39 @@ export async function searchCommand(
     console.error("❌ Error searching issues:", error.message);
     console.error("🔍 Error details:", {
       searchQuery,
+      redmineAuth,
+    });
+    process.exit(1);
+  }
+}
+
+// Function to handle 'get-entries' command
+export async function getEntriesCommand(
+  daysAgo: number,
+  redmineAuth: { username: string; password: string }
+) {
+  const date = getDateString(daysAgo);
+
+  try {
+    const entries = await fetchUserTimeEntries(redmineAuth, date);
+
+    if (entries.length > 0) {
+      console.log(`✅ Time entries for ${date}:`);
+      let totalHours = 0;
+      entries.forEach((entry) => {
+        console.log(
+          `- Issue #${entry.issue.id}: ${entry.hours}h - ${entry.comments}`
+        );
+        totalHours += entry.hours;
+      });
+      console.log(`\nTotal hours tracked: ${totalHours}h`);
+    } else {
+      console.log(`No time entries found for ${date}.`);
+    }
+  } catch (error: any) {
+    console.error("❌ Error fetching time entries:", error.message);
+    console.error("🔍 Error details:", {
+      daysAgo,
       redmineAuth,
     });
     process.exit(1);

--- a/src/lib/redmine.ts
+++ b/src/lib/redmine.ts
@@ -337,10 +337,40 @@ async function searchIssues(
   }
 }
 
+// Function to fetch the user's tracked time entries from Redmine
+async function fetchUserTimeEntries(
+  redmineAuth: RedmineAuth,
+  date: string
+): Promise<any[]> {
+  const url =
+    `${validateAndAdjustRedmineUrl(
+      process.env.REDMINE_API_URL!
+    )}time_entries.json?` +
+    `user_id=me&spent_on=${date}`;
+
+  try {
+    const response = await fetchJSON(url, {
+      headers: {
+        Authorization: createBasicAuth(redmineAuth),
+      },
+    });
+    return response.time_entries;
+  } catch (err) {
+    console.error("Failed to fetch time entries:", err);
+    console.error("🔍 Error details:", {
+      date,
+      redmineAuth,
+      url,
+    });
+    return [];
+  }
+}
+
 export {
   fetchAllProjects,
   createTask,
   trackTimeInRedmine,
   searchIssues,
   prepareRedmineEntries,
+  fetchUserTimeEntries,
 };


### PR DESCRIPTION
Implement the `redmine get-entries <daysAgo>` command to fetch and print the user's tracked time entries in Redmine.

* **Commands and Functions**
  - Add `getEntriesCommand` function in `src/lib/commands.ts` to handle fetching and printing the user's tracked time entries.
  - Update `showHelp` function in `src/lib/commands.ts` to include the `get-entries` command in the help information.
  - Add a new case for the `get-entries` command in `src/index.ts` and call the `getEntriesCommand` function with the appropriate arguments.

* **Documentation**
  - Update `README.md` to document the usage of the new `get-entries` command.

* **Redmine Integration**
  - Add `fetchUserTimeEntries` function in `src/lib/redmine.ts` to fetch the user's tracked time entries from Redmine.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/penkobor/redmine-toggle-tracker/pull/11?shareId=1f56f162-38ef-490d-bc57-f63bec46668a).