### PR TITLE
Add daysAgo parameter to track command

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,17 +71,18 @@ redmine -h
 To track hours directly to a specific task, use the following command:
 
 ```sh
-redmine track <issueID> <hours> <comment>
+redmine track <issueID> <hours> <comment> <daysAgo>
 ```
 
 - `<issueID>`: The ID of the Redmine issue.
 - `<hours>`: The number of hours to track.
 - `<comment>`: A comment describing the work done.
+- `<daysAgo>`: The number of days ago to track the hours (default is 0).
 
 Example:
 
 ```sh
-redmine track 12345 2.5 "Worked on feature X"
+redmine track 12345 2.5 "Worked on feature X" 1
 ```
 
 ### Fetch and Print Your Tracked Time Entries

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,7 @@ import {
 
 (async function main() {
   try {
-    const [command, arg1, arg2, arg3] = process.argv.slice(2);
+    const [command, arg1, arg2, arg3, arg4] = process.argv.slice(2);
 
     const redmineAuth = {
       username: process.env.REDMINE_TOKEN!,
@@ -79,10 +79,12 @@ import {
         const issueID = arg1;
         const hours = arg2 ? parseFloat(arg2) : 0;
         const comment = arg3 ?? "";
+        const daysAgoTrack = arg4 ? parseInt(arg4) : 0;
         await trackTaskCommand(
           issueID,
           hours,
           comment,
+          daysAgoTrack,
           redmineAuth,
           redmineUrl
         );

--- a/src/lib/commands.ts
+++ b/src/lib/commands.ts
@@ -17,7 +17,7 @@ export async function showHelp() {
       🚀 create-task <taskName> <projectName> - Create a new task
       🔍 search <query> - Search for issues
       ⏱️  toggle <daysAgo> <hours> - Import time entries from Toggle to Redmine
-      ⏱️  track <issueID> <hours> <comment> - Track hours directly to a task in Redmine
+      ⏱️  track <issueID> <hours> <comment> <daysAgo> - Track hours directly to a task in Redmine
       📅 get-entries <daysAgo> - Fetch and print your tracked time entries in Redmine
       ❌ delete <daysAgo> - Delete a time entry for a specific day
 
@@ -125,6 +125,7 @@ export async function trackTaskCommand(
   issueID: string,
   hours: number,
   comment: string,
+  daysAgo: number,
   redmineAuth: { username: string; password: string },
   redmineUrl: string
 ) {
@@ -142,7 +143,7 @@ export async function trackTaskCommand(
         time_entry: {
           issue_id: Number(issueID),
           hours: Math.round(hours * 100) / 100,
-          spent_on: new Date().toISOString().split("T")[0],
+          spent_on: getDateString(daysAgo),
           comments: comment,
           activity_id: 9, // Assuming 9 is the default activity ID
         },
@@ -156,6 +157,7 @@ export async function trackTaskCommand(
         issueID,
         hours,
         comment,
+        daysAgo,
         redmineAuth,
         redmineUrl,
       });


### PR DESCRIPTION
Add support for `<daysAgo>` parameter to the `track` command.

* **README.md**
  - Update the `track` command usage to include `<daysAgo>` parameter.
  - Add an example usage of the `track` command with `<daysAgo>` parameter.

* **src/index.ts**
  - Update the `track` command to accept `<daysAgo>` parameter.
  - Pass the `<daysAgo>` parameter to the `trackTaskCommand` function.

* **src/lib/commands.ts**
  - Update the `trackTaskCommand` function to handle the `<daysAgo>` parameter.
  - Adjust the `trackTaskCommand` function to use the `<daysAgo>` parameter to set the `spent_on` date.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/penkobor/redmine-toggle-tracker/pull/13?shareId=ce14cd68-6a9a-4a1d-a665-4bfcdeed2d63).