### PR TITLE
Add tab completion to CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,3 +222,23 @@ The main flow of the application is as follows:
 4. The results are displayed to the user, and any necessary user input is prompted using the functions from `src/lib/questions.ts`.
 
 This modular structure ensures that the code is organized, maintainable, and easy to understand.
+
+## 🔄 Enabling Tab Completion
+
+To enable tab completion for the `redmine` command, follow these steps:
+
+1. **Install the project globally** (if not already done):
+
+   ```sh
+   npm install -g .
+   ```
+
+2. **Run the postinstall script** to set up tab completion:
+
+   ```sh
+   npm run postinstall
+   ```
+
+3. **Restart your terminal** to apply the changes.
+
+After completing these steps, you should be able to use tab completion for the `redmine` command and its subcommands.

--- a/install.sh
+++ b/install.sh
@@ -20,4 +20,8 @@ chmod +x dist/index.js || { echo "❌ Error: Failed to make the file executable"
 echo "🌐 Installing the project globally..."
 npm install -g . || { echo "❌ Error: Failed to install the project globally"; exit 1; }
 
+# 5. Setting up tab completion
+echo "🔄 Setting up tab completion..."
+npm run postinstall || { echo "❌ Error: Failed to set up tab completion"; exit 1; }
+
 echo "🎉 Installation complete! The 'redmine' command is now available globally."

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "start": "node dist/index.js",
-    "build": "tsc"
+    "build": "tsc",
+    "postinstall": "tabtab install --name=redmine --auto"
   },
   "bin": {
     "redmine": "dist/index.js"
@@ -16,7 +17,8 @@
   "dependencies": {
     "@types/node": "^22.9.1",
     "dotenv": "^16.4.5",
-    "express": "^4.17.1"
+    "express": "^4.17.1",
+    "tabtab": "^3.0.2"
   },
   "devDependencies": {
     "typescript": "^5.0.0"

--- a/src/completion.ts
+++ b/src/completion.ts
@@ -1,0 +1,39 @@
+import tabtab from 'tabtab';
+
+const commands = [
+  'create-task',
+  'toggle',
+  'track',
+  'search',
+  'get-entries',
+  'delete'
+];
+
+tabtab.complete('redmine', (err, data) => {
+  if (err || !data) {
+    return;
+  }
+
+  const { line, last } = data;
+
+  if (line.includes('redmine')) {
+    return tabtab.log(commands, data, '--');
+  }
+
+  switch (last) {
+    case 'create-task':
+      return tabtab.log(['<taskName>', '<projectName>'], data, '--');
+    case 'toggle':
+      return tabtab.log(['<daysAgo>', '<totalHours>'], data, '--');
+    case 'track':
+      return tabtab.log(['<issueID>', '<hours>', '<comment>', '<daysAgo>'], data, '--');
+    case 'search':
+      return tabtab.log(['<query>'], data, '--');
+    case 'get-entries':
+      return tabtab.log(['<daysAgo>'], data, '--');
+    case 'delete':
+      return tabtab.log(['<daysAgo>'], data, '--');
+    default:
+      return tabtab.log(commands, data, '--');
+  }
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import dotenv from "dotenv";
 import path from "path";
 import { validateAndAdjustRedmineUrl } from "./lib/helpers";
 import { trackTaskCommand } from "./lib/commands";
+import "./completion"; // Import tab completion setup
 
 dotenv.config({ path: path.join(__dirname, "..", ".env") });
 


### PR DESCRIPTION
Add tab completion functionality to the CLI.

* **Add `tabtab` dependency**: Update `package.json` to include `tabtab` as a dependency and add a `postinstall` script to initialize tab completion.
* **Create `src/completion.ts`**: Implement tab completion logic using `tabtab` and define available commands for completion.
* **Update `src/index.ts`**: Import and initialize tab completion from `src/completion.ts`.
* **Update `README.md`**: Add instructions for enabling tab completion.
* **Update `install.sh`**: Add a post-install step to initialize tab completion.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/penkobor/redmine-toggle-tracker/pull/15?shareId=c4a3de3b-9b53-466d-ab86-10a12f68c1e2).